### PR TITLE
Fix build error in windows app engine

### DIFF
--- a/log/tty_windows.go
+++ b/log/tty_windows.go
@@ -1,4 +1,4 @@
-// +build windows
+// +build windows, !appengine
 
 package log
 


### PR DESCRIPTION
When running app engine on windows, the build fails with error: "isatty redeclared in this block" because `log/tty_windows.go` and `log/tty_safe.go` are both being built. Since `log/tty_safe.go` defaults to the windows return value, this seems sufficient.
